### PR TITLE
Update CacheLinkInterface.php

### DIFF
--- a/src/CacheLinkInterface.php
+++ b/src/CacheLinkInterface.php
@@ -2,6 +2,12 @@
 
 namespace Aol\CacheLink;
 
+const SECONDS = 1000;
+const MINUTES = 60000;
+const HOURS   = 3600000;
+const DAYS    = 86400000;
+const WEEKS   = 604800000;
+
 interface CacheLinkInterface
 {
 	/** Clears all association levels. */


### PR DESCRIPTION
Added some constants to aid in setting cache times. Rather than `$cache_time = 180000; // 3 minutes` we can now do `$cache_time = 3 * MINUTES;`. Slightly cleaner / clearer.
